### PR TITLE
Normalize punctuation.md

### DIFF
--- a/data/guidelines/en/ligatures.md
+++ b/data/guidelines/en/ligatures.md
@@ -1,3 +1,5 @@
 <span class="rule">Ligatures MUST be ignored and reduced to their individual letter components.</span>
 
-However, in modern and contemporary documents, "&" [U+0026] and "ß" [U+00DF] are not subjected to this rule.
+<span class="rule">In **medieval** documents, "&" [U+0026] is considered as its own character instead of a ligature and MUST be transcribed as is.</span> This is based on the fact that this sign can bear additional abbreviation marks, such as macrons to indicate "etiam" in Latin.
+
+<span class="rule">In **modern and contemporary** documents, both "&" [U+0026] and "ß" [U+00DF] MUST be transcribed as is.</span>

--- a/data/guidelines/en/punctuation.md
+++ b/data/guidelines/en/punctuation.md
@@ -1,35 +1,30 @@
 ## Choice of signs
 
-<span class="rule">In medieval documents, the transcription of punctuation MUST be reduced to 3 main signs:</span>
+<span class="rule">In **medieval** documents, the transcription of punctuation MUST be reduced to four main signs:</span>
 
-- "." [U+002E]
-- ":" [U+003A]
-- "," [U+002C]
+- "." [U+002E] is used for single dots,
+- ":" [U+003A] is used for dots with more than single dots,
+- "/" [U+002F] is used for diastoles and signs looking like virgulas.
+- "¶" [U+00B6] is used for section markers.
 
-<span class="rule">In modern and contemporary sources, a greater variety of punctuation signs MAY be used in order to follow modern punctuation.</span> 
+<span class="rule">In **modern and contemporary** sources, a greater variety of punctuation signs MUST be used in order to follow modern punctuation.</span> 
 
-- For example, diastoles used as commas may be transcribed with "/" [U+002F] or "," [(U+002C], depending on the sign used in the source document rather than only with ",". 
+- Diastoles used as commas MUST be transcribed with "/" [U+002F].
+- Exclamation marks, question marks and such sign must be represented as such.
+- However, the transcription of dashes MUST be reduced to one sign: "-" [U+002D] sign.
 
-<!-- Otherwise, oblique strokes should always be transcribed with "/". -->
+## Reference marks
 
-- However, the transcription of dashes MUST be reduced to one sign: "-" [U+002D] sign. 
+<span class="rule">In **medieval** documents, note-calling and insertion signs MUST be  transcribed with the CARET sign "‸" [U+2038].</span>
 
-<!-- TODO: confirm that this rule applies for medieval documents as well -->
-<!-- TODO: decide, is it "MUST" or "MAY"? -->
-Reference marks, such as "*" [U+002A], "§" [U+00A7] or "※" [U+203B] MUST be kept in the transcription.
+<span class="rule">In **modern and contemporary** documents, reference marks, such as "\*" [U+002A] or "※" [U+203B] MUST be transcribed as "\*" [U+002A]. Referencing signs such as "§" [U+00A7] MUST be transcribed as it appears.</span>
 
 ## Spacing around punctuation
 
-<span class="rule">Spacing MUST be normalized before and after punctuation</span>, such as there should always be a space after a punctuation sign (except "(", "[" or "⟦", etc.) but there should not be a space before a punctuation sign.
+<span class="rule">Spacing MUST be normalized before and after punctuation</span>. There should always be a space after a punctuation sign (except "(", "[" or "⟦", etc.) but there should not be a space before a punctuation sign.
 
 ## Dotted and dashed lines
 
 When several punctuation signs are used to fill a blank between two lines (as in "name: ........Jane...."), we MAY not try to type as many signs as traced, and rather to limit ourselves to 4 repetitions of the same symbol. 
 
 A simple dash ("-" [U+002D]) MAY be used, rather than "_" [U+005F] to transcribed dashed lines.
-
-
-<!-- 
-In **modern sources**, punctuation signs are not modernized (the [diastoles](./segmentation.md) are kept), but, when used in the source, modern punctuation signs (like the comma ",") should be transcribed as such. In more recent documents, we use modern punctuation signs.
--->
-

--- a/data/guidelines/en/punctuation.md
+++ b/data/guidelines/en/punctuation.md
@@ -19,6 +19,12 @@
 
 <span class="rule">In **modern and contemporary** documents, reference marks, such as "\*" [U+002A] or "※" [U+203B] MUST be transcribed as "\*" [U+002A]. Referencing signs such as "§" [U+00A7] MUST be transcribed as it appears.</span>
 
+## Quotation marks and apostrophes
+
+<span class="rule">Any character functioning as a marker for quotation, from French quotation mark to single quotation mark, are transcribed as standard unicode Quotation Mark [U+0022] `"`</span>
+
+<span class="rule">Apostrophes are transcribed as Single Quotation Mark `'` [U+0027].</span>
+
 ## Spacing around punctuation
 
 <span class="rule">Spacing MUST be normalized before and after punctuation</span>. There should always be a space after a punctuation sign (except "(", "[" or "⟦", etc.) but there should not be a space before a punctuation sign.

--- a/data/guidelines/en/segmentation.md
+++ b/data/guidelines/en/segmentation.md
@@ -17,12 +17,18 @@ Agglutinations and dragging strokes in cursive writing MUST NOT be imitated in t
 
 Hyphenation refers to the act of indicating that a word was cut off at the end of a line. It can be marginal in medieval manuscripts but is frequent in modern and contemporary sources.
 
-<span class="rule">Hyphenation MUST be transcribed whenever it exists in the source.</span> It MUST NOT be added when no symbol is used to signal the hyphenation in the source.
+<span class="rule">Hyphenation MUST be transcribed whenever it exists in the source.</span> 
 
-<span class="rule">Only the character "-" [U+002D] MUST be used to transcribe the hyphenation symbol</span>, whichever symbol is traced on the source. When the hyphenation symbol is repeated at the beginning of the next line, it should also be transcribed with "-" [U+002D].
+<span class="rule">The transcription MUST NOT add hyphenation symbol to signal the hyphenation in the source if the hyphenation mark is not in the source.</span>
+
+<span class="rule">The character "-" [U+002D] MUST be used to transcribe the hyphenation symbol</span>, whichever symbol is traced on the source. 
+
+<span class="rule">When the hyphenation symbol is repeated at the beginning of the next line, it should also be transcribed with "-" [U+002D].</span>
 
 
 ## Diastoles
 
-Sometimes, diastoles (vertical or oblique pen strokes) are drawn between two contiguous letters to indicate that they belong to different words. <span class="rules">Such diastoles MAY be transcribed with the sign: "/" [U+002F]</span>. 
+Sometimes, diastoles (vertical or oblique pen strokes) are drawn between two contiguous letters to indicate that they belong to different words. 
+
+<span class="rules">Word-separating diastoles MAY be transcribed with the sign "/" [U+002F]</span>. 
 


### PR DESCRIPTION
I propose to clean up the punctuation part of the document.

This includes changes regarding the annotation of reference mark (normalized as `*`) as well as normalization of the Slash annotation, as giving choice would be a pretty bad idea.